### PR TITLE
fix: linter

### DIFF
--- a/modules/auth/handlers/authHttp.go
+++ b/modules/auth/handlers/authHttp.go
@@ -103,7 +103,6 @@ func (h *authHttpHandler) AuthCallback(c *gin.Context) {
 	// Redirect with the token as a query parameter
 	redirectURL := h.conf.Auth.LineFECallbackURL + "?token=" + token
 	c.Redirect(http.StatusFound, redirectURL)
-	return
 }
 
 func (h *authHttpHandler) Logout(c *gin.Context) {

--- a/modules/auth/middlewares/authMiddlewareImpl_test.go
+++ b/modules/auth/middlewares/authMiddlewareImpl_test.go
@@ -61,7 +61,7 @@ func TestAuthMiddleware_ValidToken(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &response)
+	_ = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, "Success", response["message"])
 	assert.Equal(t, "test-user-123", response["userID"])
 }
@@ -82,7 +82,7 @@ func TestAuthMiddleware_MissingAuthorizationHeader(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
 	var response map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &response)
+	_ = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, "Unauthorized", response["error"])
 	assert.Equal(t, "Missing authorization header", response["message"])
 }
@@ -127,7 +127,7 @@ func TestAuthMiddleware_InvalidAuthorizationFormat(t *testing.T) {
 			assert.Equal(t, http.StatusUnauthorized, w.Code)
 
 			var response map[string]interface{}
-			json.Unmarshal(w.Body.Bytes(), &response)
+			_ = json.Unmarshal(w.Body.Bytes(), &response)
 			assert.Equal(t, "Unauthorized", response["error"])
 			assert.Equal(t, tt.expectedMsg, response["message"])
 		})
@@ -160,7 +160,7 @@ func TestAuthMiddleware_ExpiredToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
 	var response map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &response)
+	_ = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, "Unauthorized", response["error"])
 	assert.Equal(t, "Token has expired", response["message"])
 }
@@ -191,7 +191,7 @@ func TestAuthMiddleware_InvalidToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 
 	var response map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &response)
+	_ = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.Equal(t, "Unauthorized", response["error"])
 	assert.Equal(t, "Invalid token", response["message"])
 }

--- a/modules/auth/usecases/jwtUsecaseImpl.go
+++ b/modules/auth/usecases/jwtUsecaseImpl.go
@@ -173,7 +173,7 @@ func (a *jwtUsecaseImpl) UpsertUser(gothUser goth.User, role ...models.Role) err
 	if existingAuthMethod != nil {
 		// User exists, get the auth record
 		if existingAuthMethod.AuthID != nil {
-			auth, err = a.authRepo.GetAuthByID(ctx, *existingAuthMethod.AuthID)
+			_, err = a.authRepo.GetAuthByID(ctx, *existingAuthMethod.AuthID)
 			if err != nil {
 				return fmt.Errorf("failed to get existing auth: %w", err)
 			}

--- a/modules/cockroach/handlers/cockroachHttp.go
+++ b/modules/cockroach/handlers/cockroachHttp.go
@@ -39,7 +39,7 @@ func (h *cockroachHttpHandler) DetectCockroach(c *gin.Context) {
 			http.StatusBadRequest,
 			gin.H{"message": err.Error()},
 		)
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
@@ -51,16 +51,15 @@ func (h *cockroachHttpHandler) DetectCockroach(c *gin.Context) {
 			http.StatusBadRequest,
 			gin.H{"message": err.Error()},
 		)
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
 	if err := h.cockroachUsecase.ProcessData(reqBody); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Processing data failed"})
-		c.Error(err)
+		_ = c.Error(err)
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Success 🪳🪳🪳"})
-	return
 }

--- a/modules/cockroach/handlers/cockroachHttp_test.go
+++ b/modules/cockroach/handlers/cockroachHttp_test.go
@@ -139,7 +139,7 @@ func TestDetectCockroach(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, w.Code)
 
 			var responseBody map[string]interface{}
-			json.Unmarshal(w.Body.Bytes(), &responseBody)
+			_ = json.Unmarshal(w.Body.Bytes(), &responseBody)
 			assert.Equal(t, tt.expectedBody, responseBody)
 		})
 	}

--- a/modules/cockroach/handlers/cockroachResponse.go
+++ b/modules/cockroach/handlers/cockroachResponse.go
@@ -1,13 +1,1 @@
 package handlers
-
-import "github.com/labstack/echo/v4"
-
-type baseResponse struct {
-	Message string `json:"message"`
-}
-
-func response(c echo.Context, responseCode int, message string) error {
-	return c.JSON(responseCode, &baseResponse{
-		Message: message,
-	})
-}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -169,22 +169,22 @@ func TestIsTestEnvironment(t *testing.T) {
 	originalGoEnv := os.Getenv("GO_ENV")
 
 	defer func() {
-		os.Setenv("GIN_MODE", originalGinMode)
-		os.Setenv("GO_ENV", originalGoEnv)
+		_ = os.Setenv("GIN_MODE", originalGinMode)
+		_ = os.Setenv("GO_ENV", originalGoEnv)
 	}()
 
 	// Test with GIN_MODE=test
-	os.Setenv("GIN_MODE", "test")
+	_ = os.Setenv("GIN_MODE", "test")
 	assert.True(t, isTestEnvironment())
 
 	// Test with GO_ENV=test
-	os.Setenv("GIN_MODE", "")
-	os.Setenv("GO_ENV", "test")
+	_ = os.Setenv("GIN_MODE", "")
+	_ = os.Setenv("GO_ENV", "test")
 	assert.True(t, isTestEnvironment())
 
 	// Test without test environment
-	os.Setenv("GIN_MODE", "release")
-	os.Setenv("GO_ENV", "production")
+	_ = os.Setenv("GIN_MODE", "release")
+	_ = os.Setenv("GO_ENV", "production")
 	// Note: This might still be true because os.Args[0] contains "test"
 	// when running tests
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -175,31 +175,31 @@ func (rc *RequestContext) GetElapsedTime() time.Duration {
 // SetRequestID sets the request ID in both contexts
 func (rc *RequestContext) SetRequestID(requestID string) {
 	rc.ctx = context.WithValue(rc.ctx, RequestIDKey, requestID)
-	rc.Context.Set("request_id", requestID)
+	rc.Set("request_id", requestID)
 }
 
 // SetUserID sets the user ID in both contexts
 func (rc *RequestContext) SetUserID(userID string) {
 	rc.ctx = context.WithValue(rc.ctx, UserIDKey, userID)
-	rc.Context.Set("userID", userID)
+	rc.Set("userID", userID)
 }
 
 // SetTraceID sets the trace ID in both contexts
 func (rc *RequestContext) SetTraceID(traceID string) {
 	rc.ctx = context.WithValue(rc.ctx, TraceIDKey, traceID)
-	rc.Context.Set("trace_id", traceID)
+	rc.Set("trace_id", traceID)
 }
 
 // SetUserRole sets the user role in both contexts
 func (rc *RequestContext) SetUserRole(role string) {
 	rc.ctx = context.WithValue(rc.ctx, UserRoleKey, role)
-	rc.Context.Set("user_role", role)
+	rc.Set("user_role", role)
 }
 
 // SetUserClaims sets the user claims in both contexts
 func (rc *RequestContext) SetUserClaims(claims interface{}) {
 	rc.ctx = context.WithValue(rc.ctx, UserClaimsKey, claims)
-	rc.Context.Set("claims", claims)
+	rc.Set("claims", claims)
 }
 
 // Middleware functions

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -140,7 +140,7 @@ func Wrap(err error, errorType ErrorType, message string) *AppError {
 func WrapWithStack(err error, errorType ErrorType, message string) *AppError {
 	appErr := Wrap(err, errorType, message)
 	if appErr != nil {
-		appErr.WithStack()
+		_ = appErr.WithStack()
 	}
 	return appErr
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -65,7 +65,7 @@ func TestAppError_WithContext(t *testing.T) {
 		Context: make(map[string]interface{}),
 	}
 
-	err.WithContext("field", "username")
+	_ = err.WithContext("field", "username")
 	assert.Equal(t, "username", err.Context["field"])
 }
 
@@ -75,7 +75,7 @@ func TestAppError_WithDetails(t *testing.T) {
 		Message: "test",
 	}
 
-	err.WithDetails("detailed explanation")
+	_ = err.WithDetails("detailed explanation")
 	assert.Equal(t, "detailed explanation", err.Details)
 }
 
@@ -85,7 +85,7 @@ func TestAppError_WithStack(t *testing.T) {
 		Message: "test",
 	}
 
-	err.WithStack()
+	_ = err.WithStack()
 	assert.NotEmpty(t, err.Stack)
 	assert.Contains(t, err.Stack, "TestAppError_WithStack")
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -158,7 +158,7 @@ func (l *Logger) WithFields(fields map[string]interface{}) *Logger {
 		zapFields = append(zapFields, zap.Any(key, value))
 	}
 
-	logger := l.Logger.With(zapFields...)
+	logger := l.With(zapFields...)
 	return &Logger{
 		Logger: logger,
 		sugar:  logger.Sugar(),
@@ -167,7 +167,7 @@ func (l *Logger) WithFields(fields map[string]interface{}) *Logger {
 
 // WithField adds a single field to the logger
 func (l *Logger) WithField(key string, value interface{}) *Logger {
-	logger := l.Logger.With(zap.Any(key, value))
+	logger := l.With(zap.Any(key, value))
 	return &Logger{
 		Logger: logger,
 		sugar:  logger.Sugar(),
@@ -179,7 +179,7 @@ func (l *Logger) WithError(err error) *Logger {
 	if err == nil {
 		return l
 	}
-	logger := l.Logger.With(zap.Error(err))
+	logger := l.With(zap.Error(err))
 	return &Logger{
 		Logger: logger,
 		sugar:  logger.Sugar(),

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -503,7 +503,7 @@ func TestErrorHandler(t *testing.T) {
 	router.Use(ErrorHandler())
 
 	router.GET("/test", func(c *gin.Context) {
-		c.Error(errors.New("test error"))
+		_ = c.Error(errors.New("test error"))
 	})
 
 	req := httptest.NewRequest("GET", "/test", nil)

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -267,7 +267,7 @@ func TestValidate_Global(t *testing.T) {
 	_ = Validate(testData)
 	// May have errors due to other required fields, but should not panic
 	assert.NotPanics(t, func() {
-		Validate(testData)
+		_ = Validate(testData)
 	})
 }
 


### PR DESCRIPTION
## Fixed Issues:

errcheck (14 issues):
• Added _ = to ignore return values for json.Unmarshal calls in test files
• Added _ = to ignore return values for c.Error calls in handlers
• Added _ = to ignore return values for os.Setenv calls in tests
• Added _ = to ignore return values for method calls in error handling

staticcheck (9 issues):
• Removed redundant return statements in handler functions
• Changed unused variable assignment from auth, err = to _, err =
• Removed embedded field selectors by changing rc.Context.Set() to rc.Set() and l.Logger.With() to l.With()

unused (2 issues):
• Removed unused baseResponse struct and response function from cockroach response file